### PR TITLE
Title line fix

### DIFF
--- a/addon.js
+++ b/addon.js
@@ -582,7 +582,7 @@ builder.defineStreamHandler(async ({ type, id, name, episode, year }) => {
           streams.push({
             url: s.url,
             quality: s.quality,
-            title: `${result.title} [${s.quality}] [${sizeGB}]`, // add full title, quality and size for Stremio display
+            title: `${result.title}\n${s.quality} | ${sizeGB}`, // put quality and size on second line
             name: `Hellspy - ${s.quality}`,
           });
         }


### PR DESCRIPTION
This pull request includes a minor update to the `addon.js` file, specifically within the `builder.defineStreamHandler` function. The change adjusts the format of the `title` property for stream objects to display the quality and size on a separate line for improved readability.